### PR TITLE
Fix MSVC release builds

### DIFF
--- a/tests/os_tests/deferred_file_locker_tests.cpp
+++ b/tests/os_tests/deferred_file_locker_tests.cpp
@@ -1,8 +1,8 @@
 #include "charon/processor/deferred_file_locker.h"
 #include "charon/util/filesystem_impl.h"
 #include "charon/util/logger.h"
-#include "os_tests/skip_macros.h"
 #include "os_tests/test_files_helper.h"
+#include "os_tests/test_helpers.h"
 
 #include <gtest/gtest.h>
 #include <thread>

--- a/tests/os_tests/main.cpp
+++ b/tests/os_tests/main.cpp
@@ -1,6 +1,7 @@
 #include "charon/util/logger.h"
 #include "common/oakum_gtest_event_listener.h"
 #include "os_tests/test_files_helper.h"
+#include "os_tests/test_helpers.h"
 
 #include <gtest/gtest.h>
 
@@ -16,6 +17,8 @@ public:
 };
 
 int main(int argc, char *argv[]) {
+    populateCaches();
+
     ::testing::InitGoogleTest(&argc, argv);
 
     NullLogger logger{};

--- a/tests/os_tests/processor_tests.cpp
+++ b/tests/os_tests/processor_tests.cpp
@@ -4,7 +4,7 @@
 #include "charon/util/logger.h"
 #include "charon/util/time.h"
 #include "os_tests/fixtures/processor_config_fixture.h"
-#include "os_tests/skip_macros.h"
+#include "os_tests/test_helpers.h"
 
 #include <gtest/gtest.h>
 #include <regex>

--- a/tests/os_tests/test_helpers.cpp
+++ b/tests/os_tests/test_helpers.cpp
@@ -1,0 +1,27 @@
+#include "charon/util/logger.h"
+#include "charon/util/time.h"
+#include "os_tests/test_files_helper.h"
+#include "os_tests/test_helpers.h"
+
+#include <regex>
+
+void populateCaches() {
+    {
+        std::filesystem::path path = TestFilesHelper::createDirectory("src");
+        TestFilesHelper::createFile(path / "abc");
+    }
+    {
+        const std::regex base_regex("abc");
+    }
+    {
+        const auto path = TestFilesHelper::getTestFilePath("log.txt");
+        TimeImpl time{};
+        FileLogger logger{time, path, defaultLogLevel};
+        logger.log(LogLevel::Error, "abc");
+    }
+    {
+        TimeImpl time{};
+        ConsoleLogger logger{time, defaultLogLevel};
+        logger.log(LogLevel::Info, "Caches populated");
+    }
+}

--- a/tests/os_tests/test_helpers.h
+++ b/tests/os_tests/test_helpers.h
@@ -17,3 +17,7 @@
     if (!filesystem.isFileLockingSupported()) {  \
         SKIP();                                  \
     }
+
+// In release config some compilers may generate some lazily populated caches for STD classes. These can be reported
+// as memory leaks. We can call them early, to populate these caches before any tests.
+void populateCaches();


### PR DESCRIPTION
In release config MSVC generates some lazily populated caches for STD classes. These can be reported as memory leaks. We can call them early, to populate these caches before any tests.